### PR TITLE
Changes to Datadog metrics

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -16,18 +16,7 @@ import {
   ShareModal,
   closeAllModals
 } from './modals.js';
-
-
-// Datadog Stats
-import { datadogLogs } from '@datadog/browser-logs'
-
-datadogLogs.init({
-  clientToken: 'pub17f8509ed78f912fb055aeaa4a5d8a39',
-  site: 'datadoghq.com',
-  service: 'starfish.keuzetool',
-  forwardErrorsToLogs: false, // We don't really care about errors
-  sampleRate: 100,
-})
+import { logPageHelped, logPageVisit } from './metrics.js';
 
 let database;
 run();
@@ -93,7 +82,7 @@ async function updatePage() {
     : renderPageNotFound()
   );
 
-  datadogLogs.logger.info('Page visit', { type: 'page.visit', name: page.name, url: document.location.hash })
+  logPageVisit();
 
   document.getElementById('search').addEventListener('click', openSearch);
   document.querySelector('#search input').addEventListener('focus', openSearch);
@@ -118,7 +107,7 @@ function sharePage(event) {
 function hasHelped(event) {
   event.preventDefault();
   
-  datadogLogs.logger.info('Page has helped', { type: 'page.helped', url: document.location.hash })
+  logPageHelped();
   document.querySelector('.helped').classList.add('hasHelped');
 }
 

--- a/src/metrics.js
+++ b/src/metrics.js
@@ -1,0 +1,39 @@
+// Datadog Stats
+import { datadogLogs } from '@datadog/browser-logs'
+
+datadogLogs.init({
+  clientToken: 'pub17f8509ed78f912fb055aeaa4a5d8a39',
+  site: 'datadoghq.com',
+  service: 'verwijsafspraken',
+  sampleRate: 100,
+});
+
+function getPageUrl() {
+  return document.location.hash.slice(1);
+}
+
+function log({ type = 'info', message, ...options }) {
+  const attributes = {
+    ...options,
+    view: {
+      url: getPageUrl(),
+      ...options.view
+    }
+  };
+  datadogLogs.logger.log(message, attributes, type);
+}
+
+export function logPageVisit() {
+  log({
+    message: `Visit page`,
+    action: "page.visit",
+  });
+}
+
+export function logPageHelped() {
+  log({
+    message: "Page helped",
+    action: "page.helped"
+  })
+}
+


### PR DESCRIPTION
This:

* moves the logging/metrics to a separate module
* renames the service to `verwijsafspraken`
* Avoids overwriting `type` and instead use `action` for `page.visit` and `page.helped`
* Enable error logging (why not? :sweat_smile:)