### PR TITLE
add referrer information

### DIFF
--- a/src/metrics.js
+++ b/src/metrics.js
@@ -12,11 +12,14 @@ function getPageUrl() {
   return document.location.hash.slice(1);
 }
 
+let referrer = document.referrer;
+
 function log({ type = 'info', message, ...options }) {
   const attributes = {
     ...options,
     view: {
       url: getPageUrl(),
+      referrer,
       ...options.view
     }
   };
@@ -28,6 +31,7 @@ export function logPageVisit() {
     message: `Visit page`,
     action: "page.visit",
   });
+  referrer = document.location.href;
 }
 
 export function logPageHelped() {


### PR DESCRIPTION
Currently referrer information is blank in Datadog. This is unfortunate, because the website is being called from different sources (amongst others, Facebook). It would be useful to know from where the site is being called and from which pages.

The referrer information is usually handled by Datadog, but I think because we're overwriting `view` it won't output the right referrer information, so we also need to handle this ourselves.

I also change the referrer to the current page after every page visit, so that we can see from where people are navigating inside the site itself.