### PR TITLE
initial work on editing pages

### DIFF
--- a/src/editor.js
+++ b/src/editor.js
@@ -1,0 +1,117 @@
+const { GitHubAuthClient } = require("./github-auth-client");
+const { GitHubClient } = require("./github-client");
+
+const githubAuthClient = new GitHubAuthClient({
+  clientId: "7b5e83ed2fd7b79ee525",
+  clientSecret: "24d784d5333425052faa9609aec5190f0444c408",
+  scope: "public_repo",
+  async getUser(token) {
+    console.log('got token', token)
+    const client = new GitHubClient({ token });
+    const viewer = await client.getViewer();
+    console.log('got viewer', { viewer })
+    if (!viewer) {
+      return null;
+    }
+    return {
+      ...viewer,
+      token,
+    };
+  },
+});
+
+export async function getUser() {
+  return await githubAuthClient.authenticate();
+}
+
+export async function getGitHubClient() {
+  const user = await getUser();
+  if (!user) {
+    return null;
+  }
+  return new GitHubClient({ token: user.token });
+}
+
+export async function login() {
+    githubAuthClient.login();
+}
+
+const verwijsafsprakenRepoInfo = {
+  owner: 'verwijsafspraken',
+  repo: 'verwijsafspraken'
+}
+
+function stripNode({ url, path, parent, ...node }) {
+  return {
+    ...node,
+    children: node?.children?.map(stripNode)
+  }
+}
+
+export async function saveDatabase(database) {
+  const githubClient = await getGitHubClient();
+  if (!githubClient) {
+    githubAuthClient.login();
+    return;
+  }
+  const content = JSON.stringify(stripNode(database), null, 2) + '\n';
+
+  const { object: { sha: baseCommitSha } } = await githubClient.getRef({ ...verwijsafsprakenRepoInfo, ref: 'heads/main' });
+  const { tree: { sha: baseTreeSha } } = await githubClient.getCommit({ ...verwijsafsprakenRepoInfo, commitSha: baseCommitSha });
+  const { tree: baseTree } = await githubClient.getTree({ ...verwijsafsprakenRepoInfo, treeSha: baseTreeSha });
+
+  const forkedRepository = await ensureFork(githubClient, verwijsafsprakenRepoInfo);
+  const repositoryId = forkedRepository.id;
+  const owner = forkedRepository.owner.login;
+  const repo = forkedRepository.name;
+  const { sha: treeSha } = await githubClient.createTree({
+    owner,
+    repo,
+    baseTree: baseTreeSha,
+    tree: [{
+      path: 'database.json',
+      mode: '100644',
+      type: 'blob',
+      // sha: blobSha,
+      content
+    }]
+  });
+  const { sha: commitSha } = await githubClient.createCommit({
+    owner,
+    repo,
+    parents: [
+      baseCommitSha
+    ],
+    tree: treeSha,
+    committer: {
+      name: "Verwijsafspraken.nl",
+      email: "info@verwijsafspraken.nl",
+    },
+    message: `content changes from website`
+  });
+  const branchName = `patch-${commitSha}`;
+  await githubClient.createRef({ owner, repo, ref: `refs/heads/${branchName}`, sha: commitSha });
+  const { html_url: pullRequestUrl } = await githubClient.createPullRequest({
+    ...verwijsafsprakenRepoInfo,
+    base: 'main',
+    head: `${owner}:${branchName}`,
+    title: "Hallo",
+    body: `This PR was created by Verwijsafspraken.nl.`,
+    maintainerCanModify: true
+  })
+  return pullRequestUrl;
+}
+
+async function ensureFork(client, { owner, repo }) {
+  const repository = await client.getMyFork({ owner, repo });
+  if (!repository) {
+    return await client.forkRepo({ owner, repo });
+  }
+  return {
+    id: repository.databaseId,
+    name: repository.name,
+    owner: {
+      login: repository.owner.login
+    }
+  };
+}

--- a/src/github-auth-client.js
+++ b/src/github-auth-client.js
@@ -1,0 +1,157 @@
+function uuidv4() {
+  return ([1e7] + -1e3 + -4e3 + -8e3 + -1e11).replace(/[018]/g, (c) =>
+    (
+      c ^
+      (crypto.getRandomValues(new Uint8Array(1))[0] & (15 >> (c / 4)))
+    ).toString(16)
+  );
+}
+
+class GitHubAuthClient {
+  constructor({ clientId, clientSecret, getUser, scope = "public_repo" }) {
+    this.clientId = clientId;
+    this.clientSecret = clientSecret;
+    this.scope = scope;
+    this.getUser = getUser;
+  }
+
+  async storedAuthentication() {
+    const storedToken = window.localStorage.getItem("github_access_token");
+    if (!storedToken) {
+      return null;
+    }
+    return await this.getUser(storedToken);
+  }
+
+  async personalAccessTokenAuthentication() {
+    const url = new URL(window.location.href);
+    const hash = new URLSearchParams(url.hash.slice(1));
+    const token = hash.get("token");
+    if (!token) {
+      return null;
+    }
+    const result = await this.getUser(token);
+    if (result) {
+      // Remove token from URL if it is valid.
+      hash.delete("token");
+      url.hash = hash.toString();
+      window.history.replaceState(
+        window.history.state,
+        document.title,
+        url.toString()
+      );
+
+      window.localStorage.setItem("github_access_token", token);
+    }
+    return result;
+  }
+
+  async oauthCallbackAuthentication() {
+    const url = new URL(window.location.href + window.location.hash);
+    const params = url.searchParams;
+    const code = params.get("code");
+    const state = params.get("state");
+
+    if (!code) {
+      return null;
+    }
+
+    const storedState = window.localStorage.getItem("github_oauth_state");
+    if (storedState !== state) {
+      throw new Error("OAuth error: invalid state");
+    }
+
+    const parameters = new URLSearchParams({
+      client_id: this.clientId,
+      client_secret: this.clientSecret,
+      code,
+    });
+    const response = await fetch(
+      // AWS service to allow CORS GitHub access_token calls:
+      "https://d5pweeyzg2.execute-api.us-east-1.amazonaws.com/login/oauth/access_token",
+      {
+        method: "POST",
+        mode: "cors",
+        headers: {
+          "Content-Type": "application/x-www-form-urlencoded",
+        },
+        body: parameters.toString(),
+      }
+    );
+    const responseText = await response.text();
+    console.log(responseText);
+    const responseParams = new URLSearchParams(responseText);
+    const error = responseParams.get("error");
+    if (error) {
+      console.error({ error });
+      url.searchParams.delete('code');
+      url.searchParams.delete('state');
+      window.history.replaceState(null, '', url);
+      const errorDescription = responseParams.get("error_description");
+      throw new Error(`OAuth error: ${error}: ${errorDescription}`);
+    }
+    const token = responseParams.get("access_token");
+
+    window.localStorage.removeItem("github_oauth_state");
+
+    // Make sure the URL doesn't show the code and state anymore.
+    // Using the history API avoids doing a redirect.
+    url.searchParams.delete('code');
+    url.searchParams.delete('state');
+    window.history.replaceState(null, '', url);
+    window.history.replaceState(null, '', url);
+
+    const result = await this.getUser(token);
+    console.log({  result });
+    if (result) {
+      window.localStorage.setItem("github_access_token", token);
+    }
+    return result;
+  }
+
+  async authenticate() {
+    const url = new URL(window.location.href);
+
+    const attempts = [
+      () => this.oauthCallbackAuthentication(),
+      () => this.personalAccessTokenAuthentication(),
+      () => this.storedAuthentication(),
+    ];
+
+    for (const attempt of attempts) {
+      console.log(attempt.toString());
+      const result = await attempt();
+      if (result) {
+        console.log('result', { result });
+        return result;
+      }
+    }
+    console.log('no result');
+    return null;
+  }
+
+  login() {
+    const state = uuidv4();
+    window.localStorage.setItem("github_oauth_state", state);
+
+    const redirect_uri = window.location.href;
+
+    const parameters = new URLSearchParams({
+      client_id: this.clientId,
+      client_secret: this.clientSecret,
+      redirect_uri: redirect_uri.toString(),
+      scope: this.scope,
+      state,
+    });
+    const url = `https://github.com/login/oauth/authorize?${parameters.toString()}`;
+    window.location.assign(url);
+  }
+
+  logout() {
+    window.localStorage.removeItem("github_access_token");
+  }
+}
+
+module.exports = {
+  GitHubAuthClient,
+};

--- a/src/github-client.js
+++ b/src/github-client.js
@@ -1,0 +1,196 @@
+import { GraphQLClient, gql } from "./graphql-client";
+
+export class GitHubClient {
+  constructor({ token }) {
+    this.token = token;
+    const graphqlUrl = "https://api.github.com/graphql";
+    const headers = token ? { authorization: `token ${token}` } : {};
+    this.graphql = new GraphQLClient(graphqlUrl, {
+      headers,
+    });
+  }
+
+  async request({ method = 'GET', path, query = {}, body = null }) {
+    const url = new URL(`https://api.github.com`);
+    url.pathname = path;
+    for (const [key, value] of Object.entries(query)) {
+      url.searchParams.set(key, value);
+    }
+    console.log('request', {
+      method,
+      path,
+      query,
+      body
+    })
+    const response = await fetch(url, {
+      method,
+      headers: {
+        "Accept": "application/vnd.github+json",
+        "Authorization": `token ${this.token}`,
+        ...(body && {
+          "Content-Type": "application/json",
+        })
+      },
+      ...(body && {
+        body: JSON.stringify(body)
+      })
+    });
+    if (response.status < 200 || response.status >= 300) {
+      throw new Error(`Failed to request github: ${response.status} ${response.statusText}: ${await response.text()}`)
+    }
+    return await response.json();
+  }
+
+  async getViewer() {
+    const result = await this.graphql.request(gql`
+      query {
+        viewer {
+          name
+          login
+          avatarUrl
+        }
+      }
+    `);
+    return result.viewer;
+  }
+
+  async getMyFork({ owner, repo }) {
+    const result = await this.graphql.request(gql`
+      query($owner:String!, $repo: String!) { 
+        repository(owner:$owner, name: $repo) {
+          forks(first: 1, ownerAffiliations: OWNER) {
+            nodes {
+              databaseId
+              name,
+              owner {
+                login
+              }
+            }
+          }
+        }
+      }
+    `, { owner, repo });
+    return result?.repository?.forks?.nodes?.[0];
+  }
+  
+  async forkRepo({ owner, repo }) {
+    return await this.request({
+      method: 'POST',
+      path: `/repos/${owner}/${repo}/forks`,
+      body: {
+        name: repo,
+        default_branch_only: true
+      }
+    });
+  }
+
+  // https://docs.github.com/en/rest/git/commits#get-a-commit
+  async getCommit({ owner, repo, commitSha }) {
+    return await this.request({
+      method: 'GET',
+      path: `/repos/${owner}/${repo}/git/commits/${commitSha}`,
+    });
+  }
+
+  // https://docs.github.com/en/rest/git/commits#create-a-commit
+  async createCommit({ owner, repo, message, tree, parents, author, committer, signature }) {
+    return await this.request({
+      method: 'POST',
+      path: `/repos/${owner}/${repo}/git/commits`,
+      body: {
+        message,
+        tree,
+        parents,
+        author,
+        committer,
+        signature
+      }
+    });
+  }
+
+  // https://docs.github.com/en/rest/git/blobs#create-a-blob
+  async createBlob({ owner, repo, content }) {
+    return await this.request({
+      method: 'POST',
+      path: `/repos/${owner}/${repo}/git/blobs`,
+      body: {
+        content
+      }
+    });
+  }
+
+  async getTree({ owner, repo, treeSha }) {
+    return await this.request({
+      method: 'GET',
+      path: `/repos/${owner}/${repo}/git/trees/${treeSha}`,
+    });
+  }
+
+  async createTree({ owner, repo, tree, baseTree }) {
+    return await this.request({
+      method: 'POST',
+      path: `/repos/${owner}/${repo}/git/trees`,
+      body: {
+        tree,
+        base_tree: baseTree
+      }
+    });
+  }
+
+  // https://docs.github.com/en/rest/git/refs#get-a-reference
+  async getRef({ owner, repo, ref }) {
+    return await this.request({
+      method: 'GET',
+      path: `/repos/${owner}/${repo}/git/ref/${ref}`,
+    });
+  }
+
+  async createRef({ owner, repo, ref, sha }) {
+    return await this.request({
+      method: 'POST',
+      path: `/repos/${owner}/${repo}/git/refs`,
+      body: {
+        ref,
+        sha
+      }
+    });
+  }
+
+  // https://docs.github.com/en/rest/pulls/pulls#create-a-pull-request
+  async createPullRequest({
+    owner,
+    repo,
+    title,
+    head,
+    base,
+    body,
+    maintainerCanModify,
+    draft,
+    issue,
+  }) {
+    return await this.request({
+      method: 'POST',
+      path: `/repos/${owner}/${repo}/pulls`,
+      body: {
+        title,
+        head,
+        base,
+        body,
+        maintainer_can_modify: maintainerCanModify,
+        draft,
+        issue
+      }
+    });
+  }
+
+  async *paginate(queryFn) {
+    let after = null;
+    do {
+      const { pageInfo, edges } = await queryFn(after);
+      for (const edge of edges) {
+        yield edge;
+      }
+      after = pageInfo.hasNextPage ? pageInfo.endCursor : null;
+    } while (after);
+  }
+}

--- a/src/graphql-client.js
+++ b/src/graphql-client.js
@@ -1,0 +1,50 @@
+export class GraphQLClient {
+  constructor(url, options) {
+    this.url = url;
+    this.options = options;
+  }
+
+  async rawRequest(query, variables) {
+    const response = await fetch(this.url, {
+      ...this.options,
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json",
+        ...this.options.headers,
+      },
+      body: JSON.stringify({
+        query,
+        variables,
+      }),
+    });
+    const result = await response.json();
+    return result;
+  }
+
+  async request(query, parameters) {
+    const result = await this.rawRequest(query, parameters);
+    const { data } = this.checkResult(result);
+    return data;
+  }
+
+  checkResult(result) {
+    if (result.errors && result.errors.length) {
+      throw new Error(`GraphQL query resulted in the following errors:
+    ${
+      result.errors
+        ? result.errors.map(({ message }) => `* ${message}`).join("\n")
+        : JSON.stringify(result, null, 2)
+    }`);
+    }
+    return result;
+  }
+}
+
+export function gql(chunks, ...variables) {
+  return chunks.reduce(
+    (accumulator, chunk, index) =>
+      `${accumulator}${chunk}${index in variables ? variables[index] : ""}`,
+    ""
+  );
+}

--- a/src/rendering.js
+++ b/src/rendering.js
@@ -1,12 +1,30 @@
 const marked = require('marked');
 
+function renderEditor({ user }) {
+  if (!user) {
+    return html`
+      <form style="z-index: 9999">
+        <button id="login">Login</button>
+      </form>
+    `;
+  }
+  return html`
+    <form style="z-index: 9999">
+      Hallo ${user.name}
+      <button id="edit">Edit page</button>
+    </form>
+  `;
+}
+
 function renderFrontPage(page) {
-  const { id, name, content, children, links, sticker, header, blurb } = page;
+  const { id, name, content, children, links, sticker, header, blurb, user } = page;
   return html`
     <main class="front-page">
       <nav>
         ${renderNavigation()}
-        <form></form>
+        <form>
+        </form>
+        ${renderEditor({ user })}
       </nav>
       <header>
         <h1>${header}</h1>
@@ -26,7 +44,7 @@ function renderFrontPage(page) {
 }
 
 function renderPage(page) {
-  const { id, name, content, children, links, sticker, stickerText, url } = page;
+  const { id, name, content, children, links, sticker, stickerText, url, user } = page;
   return html`
     <main class="article-page">
       <nav>
@@ -34,21 +52,24 @@ function renderPage(page) {
         <form id="search">
           <input class="search" type="text" name="" value="" autocomplete="off" placeholder="Zoeken op onderwerp" />
         </form>
+        ${renderEditor({ user })}
       </nav>
       <section class="content">
         ${renderBreadcrumb(page)}
         <section class="two-column">
           <div class="column">
-            <h1>${name}</h1>
+            <h1 data-field="name">${name}</h1>
             ${sticker !== undefined ? html`
-              <p class=${`sticker ${sticker ? 'yes' : 'no'}`}>
+              <p contenteditable="false" class=${`sticker ${sticker ? 'yes' : 'no'}`}>
                 ${stickerText || (sticker
                   ? 'Je hebt de hulp van de huisarts nodig'
                   : 'De huisarts hoeft hier niet bij betrokken te worden')
                 }
               </p>
             ` : ''}
-            ${renderMarkdown(content)}
+            <div data-field="content">
+              ${renderMarkdown(content)}
+            </div>
             <p class="article-buttons">
               <button id="helped" class="helped" data-title="${name}" data-url="${url}" data-helped-feedback="🐬 Dat vinden wij dolfijn!">Dit artikel heeft mij geholpen</button>
               <button id="share" class="share" data-title="${name}" data-url="${url}">Dit artikel delen</button>


### PR DESCRIPTION
This adds client-side editing of pages that automatically creates PRs in GitHub.

What might not be so nice technically:

* GitHub OAuth client secret is known for everyone.
* GitHub does not support CORS on its `access_token` call. AWS API is used to circumvent this (https://github.com/bobvanderlinden/issue-graph/blob/c60fe196d47db52fe732d1ce91a6f0412fb62535/src/aws-lambda.js). The issue in GitHub is known: https://github.com/isaacs/github/issues/330.
* The GitHub application is currently under my account (bobvanderlinden). This should be moved to some organization.
* The AWS API is hosted under my account. It should be moved to Nedap?

There are a number of todos for this as well:

* Decide whether this is an ok direction and workflow:
  * Is using GitHub accounts ok?
  * Is the GitHub authorization screen not too daunting?
  * How much should we guide the user before redirecting them to GitHub?
  * Editing of multiple pages and saving once?
  * Adding pages?
  * Removing pages?
  * Moving pages?
  * Changing Ja/Nee notice?
  * Changing hidden fields? (id/url)
* Fix the styling of login/edit/save buttons.
* Fix HTML to Markdown using [library](https://github.com/mixmark-io/turndown)?
* Fix the styling of the editable fields? Add :pencil2: to each field or highlight them?