### PR TITLE
only deploy on master

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,6 +14,7 @@ jobs:
           cp -r index.html database.json images CNAME docs/
           npm run build
       - name: Deploy 🚀
+        if: github.ref == 'refs/heads/master'
         uses: JamesIves/github-pages-deploy-action@4.1.1
         with:
           branch: gh-pages


### PR DESCRIPTION
Currently all PRs are automatically deployed to https://verwijsafspraken.nl/. At the moment it shows a login button from https://github.com/verwijsafspraken/verwijsafspraken/pull/25.

This PR should make sure the deploy step is only ran from the master branch.