### PR TITLE
Move Datadog from US to EU

### DIFF
--- a/src/metrics.js
+++ b/src/metrics.js
@@ -2,8 +2,8 @@
 import { datadogLogs } from '@datadog/browser-logs'
 
 datadogLogs.init({
-  clientToken: 'pub17f8509ed78f912fb055aeaa4a5d8a39',
-  site: 'datadoghq.com',
+  clientToken: 'pubde9290f61adcc5883d4b419722a24b39',
+  site: 'datadoghq.eu',
   service: 'verwijsafspraken',
   sampleRate: 100,
 });


### PR DESCRIPTION
I created a new clientToken on Datadog EU. I changed the site from US to EU, see https://docs.datadoghq.com/getting_started/site/#access-the-datadog-site.